### PR TITLE
Update jaguar.css

### DIFF
--- a/static/styles/jaguar.css
+++ b/static/styles/jaguar.css
@@ -140,6 +140,12 @@ li {
   font-size: 0.7em;
   padding: 2px 4px;
 }
+.main h4.name span.type-signature.type a {
+  color: #fff;
+}
+.main h4.name > span.type-signature:first-child {
+  margin-right: 8px;
+}
 .main h4.name span.type {
   margin-left: 5px;
 }


### PR DESCRIPTION
- added link style (white) for type-signature, but not in returnType
- added right margin for every signature before member/method name, not just the static ones
