### PR TITLE
Remove gitHead from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "author": "davidshimjs",
   "license": "MIT",
   "readmeFilename": "README.md",
-  "gitHead": "6d141bb17fe89c32212d894f721be2de27e584ff",
   "bugs": {
     "url": "https://github.com/davidshimjs/jaguarjs-jsdoc/issues"
   }


### PR DESCRIPTION
It should not be present in package.json and is due to a bug in npm
https://github.com/npm/npm/issues/3363
