### PR TITLE
Support config.templates.linenums

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ You can set options for customizing your documentations.
         "title": "",
         "description": "",
         "keyword": ""
-    }
+    },
+    "linenums": true
 }
 ```
 

--- a/conf.json
+++ b/conf.json
@@ -23,7 +23,8 @@
 			"title": "",
 			"description": "",
 			"keyword": ""
-		}
+		},
+		"linenums": false
 	},
 	"markdown": {
 		"parser": "gfm",

--- a/static/scripts/linenumber.js
+++ b/static/scripts/linenumber.js
@@ -4,14 +4,26 @@
     var source = document.getElementsByClassName('prettyprint source');
 
     if (source && source[0]) {
-        source = source[0].getElementsByTagName('code')[0];
+        var linenums = config.linenums;
 
-        numbered = source.innerHTML.split('\n');
-        numbered = numbered.map(function(item) {
-            counter++;
-            return '<span id="line' + counter + '"></span>' + item;
-        });
+        if (linenums) {
+            source = source[0].getElementsByTagName('ol')[0];
 
-        source.innerHTML = numbered.join('\n');
+            numbered = Array.prototype.slice.apply(source.children);
+            numbered = numbered.map(function(item) {
+                counter++;
+                item.id = 'line' + counter;
+            });
+        } else {
+            source = source[0].getElementsByTagName('code')[0];
+
+            numbered = source.innerHTML.split('\n');
+            numbered = numbered.map(function(item) {
+                counter++;
+                return '<span id="line' + counter + '"></span>' + item;
+            });
+
+            source.innerHTML = numbered.join('\n');
+        }
     }
 })();

--- a/tmpl/source.tmpl
+++ b/tmpl/source.tmpl
@@ -3,6 +3,6 @@
 ?>
     <section>
         <article>
-            <pre class="prettyprint source"><code><?js= data.code ?></code></pre>
+            <pre class="prettyprint source <?js= env.conf.templates.linenums ? 'linenums' : '' ?>"><code><?js= data.code ?></code></pre>
         </article>
     </section>


### PR DESCRIPTION
This option allows to show line numbers on source code.
The option is the same as used in https://github.com/terryweiss/docstrap
