### PR TITLE
Escape HTML in code examples

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -303,7 +303,7 @@ exports.publish = function(taffyData, opts, tutorials) {
                 
                 return {
                     caption: caption || '',
-                    code: code || example
+                    code: htmlsafe(code || example)
                 };
             });
         }


### PR DESCRIPTION
Fixes documentation generation for code like the following:

``` javascript
/**                                                                             
 * @example                                                                     
 * <caption>Loop something</caption>                                                  
 * for(var i = 0; i<n; i++){                                                  
 *                                                                              
 * }                                                                            
 */                                                                             
function doSomething(){}
```
