### PR TITLE
Fixes namespaces on constructor protytpes

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -30,8 +30,8 @@ $(function () {
     });
 
     // Show an item related a current documentation automatically
-    var filename = $('.page-title').data('filename').replace(/\.[a-z]+$/, '');
-    var $currentItem = $('.navigation .item[data-name*="' + filename + '"]:eq(0)');
+    var filename = $('.page-title').data('filename');
+    var $currentItem = $('.navigation .item .title a[href*="' + filename + '"]:eq(0)').parents('.item');
 
     if ($currentItem.length) {
         $currentItem


### PR DESCRIPTION
For example, the following documentation would not allow for
navigational differentiation between q and q#b when viewing the overview
for each. I.e., if the user is viewing q#b, the menu might be open for
q, or vice versa.

``` javascript
/**
 * @constructor
 */
var q = function(){};

/**
 * @memberof q
 */
q.prototype.a;

/**
 * @memberof q
 * @namespace
 */
q.prototype.b = {};

/**
 * blah blah
 */
q.prototype.b.c = {};
```
