### PR TITLE
Prevent doclet paths from being shortened twice

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -99,20 +99,14 @@ function shortenPaths(files, commonPrefix) {
     return files;
 }
 
-function resolveSourcePath(filepath) {
-    return path.resolve(process.cwd(), filepath);
-}
-
 function getPathFromDoclet(doclet) {
     if (!doclet.meta) {
         return;
     }
 
-    var filepath = doclet.meta.path && doclet.meta.path !== 'null' ?
+    return doclet.meta.path && doclet.meta.path !== 'null' ?
         doclet.meta.path + '/' + doclet.meta.filename :
         doclet.meta.filename;
-
-    return filepath;
 }
     
 function generate(title, docs, filename, resolveLinks) {
@@ -137,7 +131,7 @@ function generate(title, docs, filename, resolveLinks) {
 function generateSourceFiles(sourceFiles) {
     Object.keys(sourceFiles).forEach(function(file) {
         var source;
-        // links are keyed to the shortened path in each doclet's `meta.filename` property
+        // links are keyed to the shortened path in each doclet's `meta.shortpath.` property
         var sourceOutfile = helper.getUniqueFilename(sourceFiles[file].shortened);
         helper.registerLink(sourceFiles[file].shortened, sourceOutfile);
 
@@ -315,15 +309,13 @@ exports.publish = function(taffyData, opts, tutorials) {
 
         // build a list of source files
         var sourcePath;
-        var resolvedSourcePath;
         if (doclet.meta) {
             sourcePath = getPathFromDoclet(doclet);
-            resolvedSourcePath = resolveSourcePath(sourcePath);
             sourceFiles[sourcePath] = {
-                resolved: resolvedSourcePath,
+                resolved: sourcePath,
                 shortened: null
             };
-            sourceFilePaths.push(resolvedSourcePath);
+            sourceFilePaths.push(sourcePath);
         }
     });
     
@@ -373,13 +365,13 @@ exports.publish = function(taffyData, opts, tutorials) {
         var url = helper.createLink(doclet);
         helper.registerLink(doclet.longname, url);
 
-        // replace the filename with a shortened version of the full path
+        // add a shortened version of the full path
         var docletPath;
         if (doclet.meta) {
             docletPath = getPathFromDoclet(doclet);
             docletPath = sourceFiles[docletPath].shortened;
             if (docletPath) {
-                doclet.meta.filename = docletPath;
+                doclet.meta.shortpath = docletPath;
             }
         }
     });

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -13,7 +13,7 @@ var self = this;
     
         <?js if (data.meta) {?>
         <div class="tag-source">
-            <?js= self.linkto(meta.filename) ?>, <?js= self.linkto(meta.filename, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
+            <?js= self.linkto(meta.shortpath) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
         </div>
         <?js } ?>
     </div>


### PR DESCRIPTION
Prevent doclet paths from being shortened twice.

Solve: issue #23 (equivalent to jsdoc3/jsdoc#514)
Based on: jsdoc3/jsdoc@f958ab0
