### PR TITLE
Removed navigation items switching place

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -35,8 +35,6 @@ $(function () {
 
     if ($currentItem.length) {
         $currentItem
-            .remove()
-            .prependTo('.navigation .list')
             .show()
             .find('.itemMembers')
                 .show();


### PR DESCRIPTION
Moving navigation items to the top when selected becomes very confusing and stops the interface becoming learnable. I removed the code that caused this.