### PR TITLE
Show modules in navigation list

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -251,6 +251,32 @@ function buildNav(members) {
         });
     }
 
+    if (members.modules.length) {
+        _.each(members.modules, function (v) {
+            nav.push({
+                type: 'module',
+                longname: v.longname,
+                name: v.name,
+                members: find({
+                    kind: 'member',
+                    memberof: v.longname
+                }),
+                methods: find({
+                    kind: 'function',
+                    memberof: v.longname
+                }),
+                typedefs: find({
+                    kind: 'typedef',
+                    memberof: v.longname
+                }),
+                events: find({
+                    kind: 'event',
+                    memberof: v.longname
+                })
+            });
+        });
+    }
+
     return nav;
 }
 

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -30,7 +30,7 @@ $(function () {
     });
 
     // Show an item related a current documentation automatically
-    var filename = $('.page-title').data('filename').replace(/\.[a-z]+$/, '');
+    var filename = $('.page-title').data('filename').replace(/\.[a-z]+$/, '').replace("-", ":");
     var $currentItem = $('.navigation .item[data-name*="' + filename + '"]:eq(0)');
 
     if ($currentItem.length) {


### PR DESCRIPTION
As pointed in #25 modules are not shown in navigation panel on the left, so basically it is currently not possible to browse through documentation of a module with some loose functions inside. This PR makes such docs visible in the panel:

``` js
/** @module Helpers */

/** 
 * This is only a sample function.
 * @method
 * @return {String}
 */
function getSomething() {
    return "sth";
}
```
