### PR TITLE
A better template for exceptions

### DIFF
--- a/tmpl/exceptions.tmpl
+++ b/tmpl/exceptions.tmpl
@@ -1,30 +1,31 @@
 <?js
-    var data = obj;
+    var exceptions = obj;
+    var self = this;
 ?>
-<?js if (data.description && data.type && data.type.names) { ?>
-<dl>
-    <dt>
-        <div class="param-desc">
-        <?js= data.description ?>
-        </div>
-    </dt>
-    <dt>
-        <dl>
-            <dt>
-                Type
-            </dt>
-            <dd>
-                <?js= this.partial('type.tmpl', data.type.names) ?>
-            </dd>
-        </dl>
-    </dt>
-</dl>
-<?js } else { ?>
-    <div class="param-desc">
-    <?js if (data.description) { ?>
-        <?js= data.description ?>
-    <?js } else if (data.type && data.type.names) { ?>
-        <?js= this.partial('type.tmpl', data.type.names) ?>
-    <?js } ?>
-    </div>
-<?js } ?>
+
+<table class="params">
+    <thead>
+        <tr>
+            <th>Type</th>
+            <th class="last">When</th>
+        </tr>
+    </thead>
+    <tbody>
+
+    <?js exceptions.forEach(function(exception) { ?>
+        <tr>
+            <td class="type">
+                <?js if (exception.type && exception.type.names) {?>
+                    <?js= self.partial('type.tmpl', exception.type.names) ?>
+                <?js } ?>
+            </td>
+            <td class="description last">
+                <?js if (exception.description) { ?>
+                    <?js= exception.description ?>
+                <?js } ?>
+            </td>
+        </tr>
+    <?js }); ?>
+
+    </tbody>
+</table>

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -73,15 +73,8 @@ var self = this;
     
     <?js if (data.exceptions && exceptions.length) { ?>
     <h5>Throws:</h5>
-    <?js if (exceptions.length > 1) { ?><ul><?js
-        exceptions.forEach(function(r) { ?>
-            <li><?js= self.partial('exceptions.tmpl', r) ?></li>
-        <?js });
-    ?></ul><?js } else {
-        exceptions.forEach(function(r) { ?>
-            <?js= self.partial('exceptions.tmpl', r) ?>
-        <?js });
-    } } ?>
+    <?js= this.partial('exceptions.tmpl', exceptions) ?>
+    <?js }?>
     
     <?js if (data.returns && returns.length) { ?>
     <?js if (returns.length > 1) { ?><h5>Returns:</h5><?js } ?>


### PR DESCRIPTION
Instead of a non-styled dd/dt template, called for each exception, call
one template with a table for all exception, using same styles as
params: type and description
