### PR TITLE
Update main.less

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -47,6 +47,9 @@
             color: #fff;
             font-size: 0.7em;
             padding: 2px 4px;
+            & a {
+                color: inherit;
+            }
         }
 
         span.type {


### PR DESCRIPTION
by default, a nested in a span.type-signature gets text color from bootstrap, making it unreadable. 
this change makes the text white on colored type-signature background, by inheriting the span text color.

.main h4.name span.type-signature a {
  color: inherit;
}
