### PR TITLE
show Members/TypeDefs/Methods/Events in navigation, only for current page Object

### DIFF
--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -49,7 +49,7 @@
 </head>
 <body>
 <div id="wrap" class="clearfix">
-    <?js= this.partial('navigation.tmpl', this) ?>
+    <?js= this.partial('navigation.tmpl', filename) ?>
     <div class="main">
         <h1 class="page-title" data-filename="<?js= filename ?>"><?js= title ?></h1>
         <?js= content ?>

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -1,4 +1,5 @@
 <?js
+var data = obj;
 var self = this;
 ?>
 <div class="navigation">
@@ -9,6 +10,7 @@ var self = this;
     </div>
     <ul class="list">
     <?js
+    var filename = data.replace(/\.[a-z]+$/, '');
     this.nav.forEach(function (item) {
     ?>
         <li class="item" data-name="<?js= item.longname ?>">
@@ -18,63 +20,69 @@ var self = this;
                 <span class="static">static</span>
                 <?js } ?>
             </span>
-            <ul class="members itemMembers">
             <?js
-            if (item.members.length) {
+            if (item.longname == filename) {
             ?>
-            <span class="subtitle">Members</span>
-            <?js
-                item.members.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
-            <?js
-                });
-            }
-            ?>
-            </ul>
-            <ul class="typedefs itemMembers">
-            <?js
-            if (item.typedefs.length) {
-            ?>
-            <span class="subtitle">Typedefs</span>
-            <?js
-                item.typedefs.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
-            <?js
-                });
-            }
-            ?>
-            </ul>
-            <ul class="methods itemMembers">
-            <?js
-            if (item.methods.length) {
-            ?>
-            <span class="subtitle">Methods</span>
-            <?js
+                <ul class="members itemMembers">
+                <?js
+                if (item.members.length) {
+                ?>
+                <span class="subtitle">Members</span>
+                <?js
+                    item.members.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                    });
+                }
+                ?>
+                </ul>
+                <ul class="typedefs itemMembers">
+                <?js
+                if (item.typedefs.length) {
+                ?>
+                <span class="subtitle">Typedefs</span>
+                <?js
+                    item.typedefs.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                    });
+                }
+                ?>
+                </ul>
+                <ul class="methods itemMembers">
+                <?js
+                if (item.methods.length) {
+                ?>
+                <span class="subtitle">Methods</span>
+                <?js
 
-                item.methods.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                    item.methods.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                     });
+                }
+                ?>
+                </ul>
+                <ul class="events itemMembers">
+                <?js
+                if (item.events.length) {
+                ?>
+                <span class="subtitle">Events</span>
+                <?js
+                    item.events.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                    });
+                }
+                ?>
+                </ul>
             <?js
-                });
             }
             ?>
-            </ul>
-            <ul class="events itemMembers">
-            <?js
-            if (item.events.length) {
-            ?>
-            <span class="subtitle">Events</span>
-            <?js
-                item.events.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
-            <?js
-                });
-            }
-            ?>
-            </ul>
         </li>
     <?js }); ?>
     </ul>


### PR DESCRIPTION
In navigation part, write all UL elements only on selected element matching with current page URL

For my project, with a lot of object, it reduce HTML page size from 4Mo to 200Ko