### PR TITLE
Show @module tags in navigation panel

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,7 +108,7 @@ module.exports = function (grunt) {
         'grunt-contrib-copy',
         'grunt-contrib-clean',
         'grunt-contrib-less',
-        'grunt-jsdoc',
+        'grunt-jsdoc'
     ].forEach(function (taskName) {
         grunt.loadNpmTasks(taskName);
     });

--- a/demo/sample/dateUtils.js
+++ b/demo/sample/dateUtils.js
@@ -1,0 +1,66 @@
+/**
+ * A utility that has methods for converting dates to different formats.
+ * @module samples/dateUtils
+ */
+define([
+ ], function(
+
+ ) {
+
+  return /** @alias module:samples/dateUtils */{
+
+    /**
+     * Converts a timestamp in epoch time (milliseconds since Jan 1, 1970) to a string.
+     * The string gets returned as a string in format "date month year hour:minute:second.
+     * For example "13 Feb 1999 12:18:32"
+     *
+     * @param {number} UNIX_timestamp The date in milliseconds after Jan 1, 1970
+     *
+     * @returns {string}
+     *
+     * @static
+     */
+    unixToDateTime: function (UNIX_timestamp) {
+      var a = new Date(UNIX_timestamp);
+      var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+      var year = a.getFullYear();
+      var month = months[a.getMonth()];
+      var date = a.getDate();
+      var hour = a.getHours();
+      var min = a.getMinutes();
+      var sec = a.getSeconds();
+      var time = date + " " + month + " " + year + " " + hour + ":" + min + ":" + sec;
+      return time;
+    },
+
+    /**
+     * Date parser that handles date string generation.
+     *  @param {Date|number|string} value The date to convert to a string. It can be a JavaScript Date object,
+     *   a unix time stamp, or a string that represents a date.
+     * @param {string} format The desired date format from the parser. Valid examples are
+     * * "MM/DD/YYYY HH:mm:ss" - "09/09/2000 13:02:08"
+     * * "DDD MMM DD YYYY h:mm A" - "Tue Jan 3 2002 8:08 AM"
+     * @returns {String} Returns a string representation of the passed in date value
+     *   following the format definition provided as the format parameter. If the value cannot
+     *   be parsed, the method returns "&lt;value&gt; (Not parsed)"
+     *
+     *   @static
+     */
+    getDateString: function (value, format) {
+      //var isValid = moment(value).isValid();
+      var isValid = true;
+      var dateString;
+
+      if (isValid && value instanceof Date) {
+        dateString = moment(value).format(format);
+      } else if (isValid && !isNaN(value)) {
+        dateString = moment.unix(value).format(format);
+      } else if (isValid && typeof(value) === "string") {
+        dateString = moment(value).format(format);
+      } else {
+        dateString = value + " (Not parsed)";
+      }
+      return dateString;
+    }
+  };
+});

--- a/less/main.less
+++ b/less/main.less
@@ -299,4 +299,20 @@
             list-style-type: disc;
         }
     }
+
+    .class-description {
+        ol, ul {
+            margin-left: 25px;
+        }
+
+        ol > li {
+            list-style-type: decimal;
+            margin-bottom: 5px;
+        }
+
+        ul > li {
+            margin-bottom: 5px;
+            list-style-type: disc;
+        }
+    }
 }

--- a/less/navigation.less
+++ b/less/navigation.less
@@ -29,6 +29,12 @@
         }
     }
 
+    .typeHeading {
+        font: 600 1.1em Helvetica;
+        color: #f5f5f5;
+        border-bottom: 1px solid #333;
+    }
+
     .search {
         padding: 10px 15px;
 

--- a/publish.js
+++ b/publish.js
@@ -200,18 +200,19 @@ function attachModuleSymbols(doclets, modules) {
  * @return {string} The HTML for the navigation sidebar.
  */
 function buildNav(members) {
-    var nav = [];
+    var nav = {};
 
     if (members.namespaces.length) {
+        var namespaces = [];
+
         _.each(members.namespaces, function (v) {
-            nav.push({
+            namespaces.push({
                 type: 'namespace',
                 longname: v.longname,
                 name: v.name,
                 displayName: v.name.replace(/\b(module|event):/g, ''),
 
                 url: helper.longnameToUrl[v.longname] || v.longname,
-
                 members: find({
                     kind: 'member',
                     memberof: v.longname
@@ -230,11 +231,14 @@ function buildNav(members) {
                 })
             });
         });
+        nav.Namespaces = namespaces;
     }
 
     if (members.classes.length) {
+        var classes = [];
+
         _.each(members.classes, function (v) {
-            nav.push({
+            classes.push({
                 type: 'class',
                 longname: v.longname,
                 name: v.name,
@@ -260,11 +264,14 @@ function buildNav(members) {
                 })
             });
         });
+        nav.Classes = classes;
     }
 
     if (members.modules.length) {
+        var modules = [];
+
         _.each(members.modules, function(v) {
-            nav.push({
+            modules.push({
                 type: 'module',
                 longname: v.longname,
                 name: v.name,
@@ -290,6 +297,7 @@ function buildNav(members) {
                 })
             });
         });
+        nav.Modules = modules;
     }
 
     return nav;

--- a/publish.js
+++ b/publish.js
@@ -208,6 +208,7 @@ function buildNav(members) {
                 type: 'namespace',
                 longname: v.longname,
                 name: v.name,
+                displayName: v.name.replace(/\b(module|event):/g, ''),
                 members: find({
                     kind: 'member',
                     memberof: v.longname
@@ -234,6 +235,34 @@ function buildNav(members) {
                 type: 'class',
                 longname: v.longname,
                 name: v.name,
+                displayName: v.name.replace(/\b(module|event):/g, ''),
+                members: find({
+                    kind: 'member',
+                    memberof: v.longname
+                }),
+                methods: find({
+                    kind: 'function',
+                    memberof: v.longname
+                }),
+                typedefs: find({
+                    kind: 'typedef',
+                    memberof: v.longname
+                }),
+                events: find({
+                    kind: 'event',
+                    memberof: v.longname
+                })
+            });
+        });
+    }
+
+    if (members.modules.length) {
+        _.each(members.modules, function(v) {
+            nav.push({
+                type: 'module',
+                longname: v.longname,
+                name: v.name,
+                displayName: v.name.replace(/\b(module|event):/g, ''),
                 members: find({
                     kind: 'member',
                     memberof: v.longname

--- a/publish.js
+++ b/publish.js
@@ -209,6 +209,9 @@ function buildNav(members) {
                 longname: v.longname,
                 name: v.name,
                 displayName: v.name.replace(/\b(module|event):/g, ''),
+
+                url: helper.longnameToUrl[v.longname] || v.longname,
+
                 members: find({
                     kind: 'member',
                     memberof: v.longname
@@ -236,6 +239,9 @@ function buildNav(members) {
                 longname: v.longname,
                 name: v.name,
                 displayName: v.name.replace(/\b(module|event):/g, ''),
+
+                url: helper.longnameToUrl[v.longname] || v.longname,
+
                 members: find({
                     kind: 'member',
                     memberof: v.longname
@@ -263,6 +269,9 @@ function buildNav(members) {
                 longname: v.longname,
                 name: v.name,
                 displayName: v.name.replace(/\b(module|event):/g, ''),
+
+                url: helper.longnameToUrl[v.longname] || v.longname,
+
                 members: find({
                     kind: 'member',
                     memberof: v.longname

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -13,7 +13,7 @@ var self = this;
     ?>
         <li class="item" data-name="<?js= item.longname ?>">
             <span class="title">
-                <?js= self.linkto(item.longname, item.longname) ?>
+                <?js= self.linkto(item.longname, item.displayName) ?>
                 <?js if (item.type === 'namespace') { ?>
                 <span class="static">static</span>
                 <?js } ?>

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -9,73 +9,78 @@ var self = this;
     </div>
     <ul class="list">
     <?js
-    this.nav.forEach(function (item) {
+    Object.keys(this.nav).forEach(function(key) {
     ?>
-        <li class="item" data-name="<?js= item.url || item.longname ?>">
-            <span class="title">
-                <?js= self.linkto(item.longname, item.displayName) ?>
-                <?js if (item.type === 'namespace') { ?>
-                <span class="static">static</span>
-                <?js } ?>
-            </span>
-            <ul class="members itemMembers">
-            <?js
-            if (item.members.length) {
-            ?>
-            <span class="subtitle">Members</span>
-            <?js
-                item.members.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
-            <?js
-                });
-            }
-            ?>
-            </ul>
-            <ul class="typedefs itemMembers">
-            <?js
-            if (item.typedefs.length) {
-            ?>
-            <span class="subtitle">Typedefs</span>
-            <?js
-                item.typedefs.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
-            <?js
-                });
-            }
-            ?>
-            </ul>
-            <ul class="methods itemMembers">
-            <?js
-            if (item.methods.length) {
-            ?>
-            <span class="subtitle">Methods</span>
-            <?js
+        <h3 class="typeHeading"><?js= key ?></h3>
+        <?js
+        this.nav[key].forEach(function (item) {
+        ?>
+            <li class="item" data-name="<?js= item.url || item.longname ?>">
+                <span class="title">
+                    <?js= self.linkto(item.longname, item.displayName) ?>
+                    <?js if (item.type === 'namespace') { ?>
+                    <span class="static">static</span>
+                    <?js } ?>
+                </span>
+                <ul class="members itemMembers">
+                <?js
+                if (item.members.length) {
+                ?>
+                <span class="subtitle">Members</span>
+                <?js
+                    item.members.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                    });
+                }
+                ?>
+                </ul>
+                <ul class="typedefs itemMembers">
+                <?js
+                if (item.typedefs.length) {
+                ?>
+                <span class="subtitle">Typedefs</span>
+                <?js
+                    item.typedefs.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                    });
+                }
+                ?>
+                </ul>
+                <ul class="methods itemMembers">
+                <?js
+                if (item.methods.length) {
+                ?>
+                <span class="subtitle">Methods</span>
+                <?js
 
-                item.methods.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
-            <?js
-                });
-            }
-            ?>
-            </ul>
-            <ul class="events itemMembers">
-            <?js
-            if (item.events.length) {
-            ?>
-            <span class="subtitle">Events</span>
-            <?js
-                item.events.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
-            <?js
-                });
-            }
-            ?>
-            </ul>
-        </li>
-    <?js }); ?>
+                    item.methods.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                    });
+                }
+                ?>
+                </ul>
+                <ul class="events itemMembers">
+                <?js
+                if (item.events.length) {
+                ?>
+                <span class="subtitle">Events</span>
+                <?js
+                    item.events.forEach(function (v) {
+                ?>
+                    <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, v.name) ?></li>
+                <?js
+                    });
+                }
+                ?>
+                </ul>
+            </li>
+        <?js }); ?>
+      <?js }.bind(this)); ?>
     </ul>
 </div>

--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -11,7 +11,7 @@ var self = this;
     <?js
     this.nav.forEach(function (item) {
     ?>
-        <li class="item" data-name="<?js= item.longname ?>">
+        <li class="item" data-name="<?js= item.url || item.longname ?>">
             <span class="title">
                 <?js= self.linkto(item.longname, item.displayName) ?>
                 <?js if (item.type === 'namespace') { ?>


### PR DESCRIPTION
This PR is to fix one existing issue,  one issue I found while working with a recent version of jsdoc,  one change to the display of items in the navigation list, and one change to display markdown lists in class descriptions as bulleted lists.
* The existing issue is #25, modules tagged with `@module` do not get added to the navigation list on the left side of the page. In reference to this issue I made the following changes:
  * Added a new `if` statement to the `publish.buildNav` method to add modules to the array of items that get added to the navigation list
  * Removed `module:` from the name of the navigation item so the display name shown in the list is easier to read.

* I found an issue when using the most recent version of *jsdoc* (3.4.2) that gets bundled with the latest version of *grunt-jsdoc* (2.1.0). The `<li>` elements generated for AMD modules in the navigation list have the wrong `data-name` attribute value due to a new file naming method in recent versions of *jsdoc*.
  * The fix is to set the `data-name` attribute of the element to the file name generated generated for the module instead of setting it to the `longname` property.

* I added some entries to `main.less` to render `<li>` elements in class descriptions with `list-style-type:disc` 

* The last change is to add section labels to the navigation list so that it is easy to see the items grouped by type. This is the way that the default template for jsdoc displays items in the navigation list.