### PR TITLE
Remove Bitdeli badge [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,3 @@ You can set options for customizing your documentations.
 License
 ---
 This project under the MIT License. and this project refered by default template for JSDoc 3.
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/davidshimjs/jaguarjs-jsdoc/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-


### PR DESCRIPTION
Bitdeli is gone; the badge image and link are both broken.